### PR TITLE
[#51] - Fix profile page on mobile

### DIFF
--- a/frontend/src/app.scss
+++ b/frontend/src/app.scss
@@ -95,7 +95,7 @@
   }
 
   .content-container {
-    padding: 30px 70px;
+    padding: 30px;
 
     .content {
       background: #fff;
@@ -106,6 +106,10 @@
       p {
         font-size: 1.2em;
       }
+    }
+
+    @media (min-width: 786px) {
+      padding: 30px 70px;
     }
   }
 }

--- a/frontend/src/pages/profile/Profile.jsx
+++ b/frontend/src/pages/profile/Profile.jsx
@@ -118,7 +118,7 @@ const Profile = () => {
                     </Row>
                   </Checkbox.Group>
                 </Form.Item>
-                <Row align="middle">
+                <Row align="end">
                   <Form.Item>
                     <Button type="primary" htmlType="submit">
                       Save

--- a/frontend/src/pages/profile/profile.scss
+++ b/frontend/src/pages/profile/profile.scss
@@ -9,6 +9,7 @@
 
       .ant-checkbox-group {
         min-width: 100%;
+        width: 100%;
         max-height: 300px;
         overflow-y: scroll;
         background: #f7f8fc;


### PR DESCRIPTION
- [x] Make the box that wraps the checkboxes fit in the profile box on mobile.
- [x] Move save button to right.

 
![Screenshot 2022-06-14 08:13:21](https://user-images.githubusercontent.com/60210180/173498422-1c89745e-dc70-498b-af43-012c46c389a3.png)
